### PR TITLE
[ADD][8.0] Field product_id added on model mgmtsystem.nonconformity due to an ISO/TS 16949 requirement.

### DIFF
--- a/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
+++ b/mgmtsystem_nonconformity/models/mgmtsystem_nonconformity.py
@@ -203,6 +203,7 @@ class MgmtsystemNonconformity(models.Model):
         'Preventive action',
         domain="[('nonconformity_id', '=', id)]",
     )
+    product_id = fields.Many2one('product.product', 'Product')
 
     @property
     @api.multi

--- a/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
+++ b/mgmtsystem_nonconformity/views/mgmtsystem_nonconformity.xml
@@ -15,6 +15,7 @@
         <field name="ref"/>
         <field name="date"/>
         <field name="partner_id"/>
+        <field name="product_id"/>
         <field name="description"/>
         <field name="author_user_id"/>
         <field name="responsible_user_id"/>
@@ -53,6 +54,7 @@
           <separator orientation="vertical"/>
           <filter string="System" icon="gtk-execute" context="{'group_by':'system_id'}"/>
           <filter string="Partner" icon="terp-personal+" domain="[]" context="{'group_by':'partner_id'}"/>
+          <filter string="Product" icon="terp-personal+" domain="[]" context="{'group_by':'product_id'}"/>
           <filter string="Procedure" icon="terp-stock_symbol-selection" context="{'group_by':'procedure_ids'}"/>
           <!-- 
           <separator orientation="vertical"/>
@@ -88,6 +90,7 @@
                 <field name="ref" attrs="{'readonly':[('state','not in',['draft'])]}"/>
                 <field name="date" attrs="{'readonly':[('state','not in',['draft'])]}"/>
                 <field name="partner_id" attrs="{'readonly':[('state','not in',['draft','analysis'])]}"/>
+                <field name="product_id" attrs="{'readonly':[('state','not in',['draft','analysis'])]}"/>
                 <field name="reference" attrs="{'readonly':[('state','not in',['draft'])]}"/>
                 <field name="origin_ids" widget="many2many_tags" attrs="{'readonly':[('state','not in',['draft','analysis'])]}"/>
               </group>


### PR DESCRIPTION
Due to an ISO/TS 16949 requirement when occurs a nonconformity for any failure that could result in a probable shipment of nonconforming product, the document nonconformity requires it can be associate a product, in response to this requirement the field product_id is added to the model mgmtsystem.nonconformity

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vauxoo/management-system/1)

<!-- Reviewable:end -->
