### PR TITLE
[REF][mgmtsystem_action] get_action_url refactored method.

### DIFF
--- a/mgmtsystem_action/mgmtsystem_action.py
+++ b/mgmtsystem_action/mgmtsystem_action.py
@@ -19,8 +19,6 @@
 #
 ##############################################################################
 
-from urllib import urlencode
-from urlparse import urljoin
 from openerp import fields, models, api
 
 
@@ -92,15 +90,11 @@ class mgmtsystem_action(models.Model):
 
         return True
 
-    @api.one
+    @api.multi
     def get_action_url(self):
-        config_parameter = self.env['ir.config_parameter']
-        base_url = config_parameter.get_param('web.base_url',
-                                              default='http://localhost:8069')
-
-        query = {'db': self.env.cr.dbname}
-        fragment = {'id': self.id, 'model': self._name}
-
-        return urljoin(base_url, "?%s#%s" % (
-            urlencode(query), urlencode(fragment)
-        ))
+        partner_obj = self.env['res.partner']
+        partner_brw = partner_obj.browse(self.user_id.partner_id.id)
+        if partner_brw:
+            url = partner_brw._get_signup_url_for_action(
+                res_id=self.id, model=self._model)[partner_brw.id]
+        return url

--- a/mgmtsystem_action/tests/test_create_action.py
+++ b/mgmtsystem_action/tests/test_create_action.py
@@ -36,9 +36,14 @@ class TestModelAction(common.TransactionCase):
             "type_action": "immediate",
         })
 
+        url = self.env['ir.config_parameter'].get_param('web.base.url')
         ret = record.get_action_url()
 
-        self.assertEqual(isinstance(ret, list), True)
-        self.assertEqual(len(ret), 1)
-        self.assertEqual(isinstance(ret[0], basestring), True)
-        self.assertEqual(ret[0].startswith('http'), True)
+        self.assertIn(url, ret, 'Action link: link should contain web.base.url\
+         config parameter.')
+        self.assertIn(str(record.id), ret, 'Action link: link should contain\
+         record id.')
+        self.assertIn(record._model._name, ret, 'Action link: link should\
+         contain model name.')
+        self.assertEqual(isinstance(ret, basestring), True)
+        self.assertEqual(ret.startswith('http'), True)


### PR DESCRIPTION
The url shown corresponds to a broken or incorrectly created link that was not binding on properly action:

![actions odoo](https://cloud.githubusercontent.com/assets/7597456/14627555/190c4c36-05bb-11e6-93a6-4cdb440759e2.png)

For this code line the key is incorrect:
`base_url = config_parameter.get_param('web.base_url',
                                              default='http://localhost:8069')`
The key should be:
`web.base.url`

At [this](https://github.com/Vauxoo/management-system/blob/8.0/mgmtsystem_action/mgmtsystem_action.py#L98) code line.

The new implementation of the method is using `_get_signup_url_for_action` to obtain the url directly.

test_create_action.py is now testing that the record id created, model name and url is on the link content.
