### PR TITLE
[IMP][system_nonconformity_project] Field name requiered on mgmtsystem.action model to avoid Many2one call error.

### DIFF
--- a/mgmtsystem_nonconformity_project/models/mgmtsystem_nonconformity_project.py
+++ b/mgmtsystem_nonconformity_project/models/mgmtsystem_nonconformity_project.py
@@ -51,7 +51,7 @@ class mgmtsystem_action(orm.Model):
             type='char',
             size=250,
         ),
-        'name': fields.char('Claim Subject', size=128),
+        'name': fields.char('Claim Subject', size=128, required=True),
     }
     _defaults = {
         'action_type': 'action'


### PR DESCRIPTION
When `mgmtsystem.action` model is called in a Many2one field and the name is empty this cause an error. In the field `immediate_action_id` for `mgmtsystem.nonconformity` model the following bug is occurring: https://github.com/Vauxoo/management-system/issues/5

With this PR we solve [this](https://github.com/Vauxoo/management-system/issues/5) issue.
Dummy PR [here](https://github.com/Vauxoo/wohlert/pull/22).
