### PR TITLE
[FIX] mgmtsystem: Changed label of model field name

### DIFF
--- a/mgmtsystem/i18n/es.po
+++ b/mgmtsystem/i18n/es.po
@@ -448,8 +448,8 @@ msgstr ""
 
 #. module: mgmtsystem
 #: model:ir.model.fields,field_description:mgmtsystem.field_res_config_settings__module_mgmtsystem_quality
-msgid "Quality"
-msgstr ""
+msgid "Quality Management Tools"
+msgstr "Herramientas de Gestión de Calidad"
 
 #. module: mgmtsystem
 #: model:ir.model.fields,field_description:mgmtsystem.field_res_config_settings__module_mgmtsystem_quality_manual

--- a/mgmtsystem/models/res_config.py
+++ b/mgmtsystem/models/res_config.py
@@ -11,7 +11,7 @@ class MgmtsystemConfigSettings(models.TransientModel):
 
     # Systems
     module_mgmtsystem_quality = fields.Boolean(
-        'Quality',
+        'Quality Management Tools',
         help='Provide quality management tools.\n'
         '- This installs the module mgmtsystem_quality.'
     )


### PR DESCRIPTION
Changed to avoid warning in log due to have the same label with MRP module field name